### PR TITLE
multivalue title_vern_display for demo record set

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -467,7 +467,7 @@
    <!-- these display fields are NOT multi-valued -->
    <field name="marc_display" type="string" indexed="false" stored="true" multiValued="false"/>
    <field name="title_display" type="string" indexed="false" stored="true" multiValued="false"/>
-   <field name="title_vern_display" type="string" indexed="false" stored="true" multiValued="false"/>
+   <field name="title_vern_display" type="string" indexed="false" stored="true" multiValued="true"/>
    <field name="subtitle_display" type="string" indexed="false" stored="true" multiValued="false"/>
    <field name="subtitle_vern_display" type="string" indexed="false" stored="true" multiValued="false"/>
    <field name="author_display" type="string" indexed="false" stored="true" multiValued="false"/>


### PR DESCRIPTION
This avoids a warning when ingesting the sample record set.  It would probably make more sense to filter the results from traject or edit the sample record set, but this is expedient (I hope!)